### PR TITLE
Generate a comma-separated list instead of a space-separated one.

### DIFF
--- a/map.h
+++ b/map.h
@@ -38,10 +38,11 @@
 
 #define MAP_END(...)
 
+#define COMMA ,
 #define MAP_OUT
 #define MAP_GET_END() 0, MAP_END
 #define MAP_NEXT0(item, next, ...) next MAP_OUT
-#define MAP_NEXT1(item, next) MAP_NEXT0 (item, next, 0)
+#define MAP_NEXT1(item, next) MAP_NEXT0 (item, COMMA next, 0)
 #define MAP_NEXT(item, next)  MAP_NEXT1 (MAP_GET_END item, next)
 
 #define MAP0(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP1) (f, peek, __VA_ARGS__)
@@ -49,4 +50,3 @@
 #define MAP(f, ...) EVAL (MAP1 (f, __VA_ARGS__, (), 0))
 
 #endif
-


### PR DESCRIPTION
In C, arguments are rarely space-separated.  This changes the MAP macro so that it'll expand a comma-separated list instead.
