### PR TITLE
Allow using parens in arguments

### DIFF
--- a/map.h
+++ b/map.h
@@ -39,13 +39,15 @@
 #define MAP_END(...)
 #define MAP_OUT
 
-#define MAP_GET_END() 0, MAP_END
+#define MAP_GET_END2() 0, MAP_END
+#define MAP_GET_END1(...) MAP_GET_END2
+#define MAP_GET_END(...) MAP_GET_END1
 #define MAP_NEXT0(test, next, ...) next MAP_OUT
 #define MAP_NEXT1(test, next) MAP_NEXT0 (test, next, 0)
 #define MAP_NEXT(test, next)  MAP_NEXT1 (MAP_GET_END test, next)
 
 #define MAP0(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP1) (f, peek, __VA_ARGS__)
 #define MAP1(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP0) (f, peek, __VA_ARGS__)
-#define MAP(f, ...) EVAL (MAP1 (f, __VA_ARGS__, (), 0))
+#define MAP(f, ...) EVAL (MAP1 (f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
 
 #endif


### PR DESCRIPTION
Sometimes it might come in handy to have parenthesized arguments like
```c
MAP(F, (a,1), (b,2), (c,3));
```

This caused `error: macro "MAP_GET_END" passed 2 arguments, but takes
just 0` before.

This PR enables the use of parenthesized arguments as in
```c
MAP(F, (a,1), (b,2), (c,3));
```
or
```c
MAP(F, (a)(1), (b)(2), (c)(3));
```

Using an argument `(1)(2)(3)` is currently not possible, but would only
need adding one further line.