### PR TITLE
Added simple unit test via GitHub Actions for Windows, OS X & Linux

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -1,0 +1,47 @@
+# Copyright (c) 2019-2020-2021 Luca Cappa
+# Released under the term specified in file LICENSE.txt
+# SPDX short identifier: MIT
+name: mapmacro-test
+on: [push, pull_request]
+
+jobs:
+  buildtest:
+    name: ${{ matrix.os }}-hosted-basic
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        include:
+          - vcpkgCommitId: 'a9eee3b18df395dbb8be71a31bd78ea441056e42'
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - uses: lukka/get-cmake@v4.0.2
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        id: runvcpkg
+        with:
+          # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+          # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
+          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
+          # The vcpkg.json file, which will be part of cache key computation.
+          vcpkgJsonGlob: '**/cmakepresets/vcpkg.json'
+      - name: Run CMake consuming CMakePreset.json and run vcpkg to build packages
+        uses: lukka/run-cmake@v10.8
+        with:
+          # This is the name of the CMakePresets.json's configuration to use to generate
+          # the project files. This configuration leverages the vcpkg.cmake toolchain file to
+          # run vcpkg and install all dependencies specified in vcpkg.json.
+          configurePreset: 'ninja-multi-vcpkg'
+
+          # This is the name of the CMakePresets.json's configuration to build the project.
+          buildPreset: 'ninja-multi-vcpkg'
+
+          # This is the name of the CMakePresets.json's configuration to test the project with.
+          testPreset: 'ninja-multi-vcpkg'
+          testPresetAdditionalArgs: "['-C', 'Debug']"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(MapMacroTestsuite)
+enable_testing()
+
+add_custom_command(
+    OUTPUT  autotest.c
+    COMMAND python ${CMAKE_SOURCE_DIR}/gentest.py ${CMAKE_CURRENT_BINARY_DIR}/autotest.c
+    DEPENDS gentest.py
+)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED True)
+
+add_executable(MapMacroTestsuite ${CMAKE_CURRENT_BINARY_DIR}/autotest.c ${CMAKE_SOURCE_DIR}/map.h)
+
+target_include_directories(MapMacroTestsuite PRIVATE ${CMAKE_SOURCE_DIR})
+
+
+add_test(NAME MapMacroTestsuite COMMAND MapMacroTestsuite)
+

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,137 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ninja",
+      "displayName": "Ninja Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Ninja"
+    },
+    {
+      "name": "ninja-toolchain",
+      "displayName": "Ninja Configure Settings with toolchain",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/builds/${presetName}-toolchain",
+      "generator": "Ninja",
+      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    },
+    {
+      "name": "ninja-multi-vcpkg",
+      "displayName": "Ninja Multi-Config Configure Settings",
+      "description": "Configure with vcpkg toolchain",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
+    },
+    {
+      "name": "msbuild-vcpkg",
+      "displayName": "MSBuild (vcpkg toolchain) Configure Settings",
+      "description": "Configure with VS generators and with vcpkg toolchain",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Visual Studio 17 2022",
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ninja",
+      "configurePreset": "ninja",
+      "displayName": "Build with Ninja",
+      "description": "Build with Ninja"
+    },
+    {
+      "name": "ninja-multi-vcpkg",
+      "configurePreset": "ninja-multi-vcpkg",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations"
+    },
+    {
+      "name": "ninja-toolchain",
+      "configurePreset": "ninja-toolchain",
+      "displayName": "Build ninja-toolchain",
+      "description": "Build ninja with a toolchain"
+    },
+    {
+      "name": "msbuild-vcpkg",
+      "configurePreset": "msbuild-vcpkg",
+      "displayName": "Build MSBuild",
+      "description": "Build with MSBuild (VS)"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ninja",
+      "configurePreset": "ninja"
+    },
+    {
+      "name": "ninja-multi-vcpkg",
+      "configurePreset": "ninja-multi-vcpkg"
+    },
+    {
+      "name": "default-vs",
+      "configurePreset": "msbuild-vcpkg"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "ninja-workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "ninja-multi-vcpkg"
+        },
+        {
+          "type": "build",
+          "name": "ninja-multi-vcpkg"
+        },
+        {
+          "type": "test",
+          "name": "ninja-multi-vcpkg"
+        }
+      ]
+    }
+  ],
+  "packagePresets": [
+    {
+      "packageName": "default-package-name",
+      "packageVersion": "0.1",
+      "name": "default",
+      "configurePreset": "ninja",
+      "generators": [
+        "TGZ"
+      ]
+    },
+    {
+      "packageName": "default-multi-package-name",
+      "packageVersion": "0.1",
+      "name": "ninja-multi-vcpkg",
+      "configurePreset": "ninja-multi-vcpkg",
+      "generators": [
+        "TGZ"
+      ],
+      "configurations": [
+        "Debug"
+      ]
+    }
+  ]
+}

--- a/gentest.py
+++ b/gentest.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+
+import sys
+
+max = 365
+
+file = open(sys.argv[1], "w")
+
+file.write("""#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include <stddef.h>
+#include "map.h"
+
+#define M0(x) "[" #x "]",
+#define M1(x) "[" #x "]"
+#define M2(x) x
+#define M3(x,y) "[" #x "," #y "]",
+#define M4(x,y) "[" #x "," #y "]"
+#define M5(x,y,z) "[" #x "," #y "," #z "]" ,
+#define M6(x,y,z) "[" #x "," #y "," #z "]"
+
+
+void testArray (const char* got [], const char* expected []){
+	for (size_t i = 0; expected [i] != NULL; ++i) {
+		assert (strcmp (got [i], expected [i]) == 0);
+	}
+}
+
+int main () {
+""")
+
+def testcase(macro,cb,append,mkelem):
+	file.write('\t{\n\t\tconst char* got [] = { '+ macro + ' (' + cb + ',')
+	file.write(','.join(str(x) for x in range(0,max)))
+	file.write(') ' + append + ' };\n\t\tconst char* expected [] = {')
+	file.write(', '.join('"' + mkelem(x) + '"' for x in range(0,max)))
+	file.write(', NULL};\n\t\ttestArray(got,expected);\n\t}\n')
+
+testcase('MAP','M0', 'NULL', lambda x : '[' + str(x) + ']')
+
+testcase('MAP_LIST','M1', '', lambda x : '[' + str(x) + ']')
+
+testcase('MAP_UD','M3, ud', 'NULL', lambda x : '[' + str(x) + ',ud]')
+
+testcase('MAP_LIST_UD','M4, ud', '', lambda x : '[' + str(x) + ',ud]')
+
+testcase('MAP_UD_I','M5, ud', 'NULL', lambda x : '[' + str(x) + ',ud,' + str(x) + ']')
+
+testcase('MAP_LIST_UD_I','M6, ud', '', lambda x : '[' + str(x) + ',ud,' + str(x) + ']')
+
+
+file.write('\tputs("All tests succeeded.");\n\treturn 0;\n}\n')
+


### PR DESCRIPTION
This branch adds a simple unit test built via CMake based on code generation via a python script. This test is automatically run via GitHub actions on Windows, Linux, Mac OS X using the MSVC, GCC and Clang compilers, respectively. This allows us to automatically check contributions on those common compilers without locally installing. New test cases can easily be added via the python code generator.